### PR TITLE
chore: disable Dependabot version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
### **User description**
## What changed
Set `open-pull-requests-limit: 0` on every configured Dependabot update entry in `.github/dependabot.yml`.

## Why
We want to stop Dependabot from opening version update PRs while keeping Dependabot's security scanning behavior in place, because dependency update automation is moving to Renovate.

## Impact
Dependabot will no longer open routine update PRs for Go modules or GitHub Actions in this repository.

## Validation
- Confirmed both configured ecosystems now include `open-pull-requests-limit: 0`
- Ran `git diff --check -- .github/dependabot.yml`


___

### **PR Type**
Other


___

### **Description**
- Disable Dependabot update PR creation

- Set PR limit for `gomod`

- Set PR limit for `github-actions`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  dep["Dependabot configuration"]
  gomod["gomod updates"]
  gha["github-actions updates"]
  limit["open-pull-requests-limit: 0"]

  dep -- "applies to" --> gomod
  dep -- "applies to" --> gha
  gomod -- "sets" --> limit
  gha -- "sets" --> limit
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Disable Dependabot PRs for configured ecosystems</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Add <code>open-pull-requests-limit: 0</code> to <code>gomod</code><br> <li> Add <code>open-pull-requests-limit: 0</code> to <code>github-actions</code><br> <li> Prevent routine Dependabot update PRs</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/go-sb-testclient/pull/43/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

